### PR TITLE
remove libdecor cairo plugin deployment

### DIFF
--- a/mednafen-appimage.sh
+++ b/mednafen-appimage.sh
@@ -39,7 +39,7 @@ export DEPLOY_PIPEWIRE=1
 # ADD LIBRARIES
 wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
 chmod +x ./quick-sharun
-./quick-sharun /usr/bin/mednafen /usr/lib/libdecor/*/libdecor-cairo.so
+./quick-sharun /usr/bin/mednafen
 
 # turn appdir into appimage
 wget --retry-connrefused --tries=30 "$URUNTIME" -O ./uruntime2appimage


### PR DESCRIPTION
No longer needed due to: 

* https://github.com/pkgforge-dev/Anylinux-AppImages/pull/242

* https://github.com/pkgforge-dev/Anylinux-AppImages/commit/cfe6efe098e87a96a3e3893865239f0e526d58da